### PR TITLE
Create simple superflat world

### DIFF
--- a/src/vulkan_app/app.rs
+++ b/src/vulkan_app/app.rs
@@ -2,7 +2,7 @@ use ash::{vk, Entry};
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
 use super::utils::{QueueFamilyIndices, UniformBufferObject};
-use super::vertex::{Vertex, INDICES, VERTICES, generate_wireframe_vertices};
+use super::vertex::generate_flat_world;
 use super::{buffers, commands, descriptors, images, instance, pipeline, swapchain};
 
 pub struct VulkanApp {
@@ -39,6 +39,7 @@ pub struct VulkanApp {
     pub(super) wireframe_vertex_buffer: vk::Buffer,
     pub(super) wireframe_vertex_buffer_memory: vk::DeviceMemory,
     pub(super) wireframe_vertex_count: u32,
+    pub(super) index_count: u32,
     pub(super) index_buffer: vk::Buffer,
     pub(super) index_buffer_memory: vk::DeviceMemory,
     pub(super) uniform_buffers: Vec<vk::Buffer>,
@@ -72,14 +73,14 @@ impl VulkanApp {
         let (device, graphics_queue, present_queue) =
             instance::create_logical_device(&instance, physical_device, &queue_family_indices);
 
+        let (world_vertices, world_indices, wire_vertices) = generate_flat_world(20, 20);
         let (vertex_buffer, vertex_buffer_memory) = buffers::create_vertex_buffer(
             &instance,
             &device,
             physical_device,
             &queue_family_indices,
-            &VERTICES,
+            &world_vertices,
         );
-        let wire_vertices = generate_wireframe_vertices(24);
         let wireframe_vertex_count = wire_vertices.len() as u32;
         let (wireframe_vertex_buffer, wireframe_vertex_buffer_memory) =
             buffers::create_vertex_buffer(
@@ -89,12 +90,13 @@ impl VulkanApp {
                 &queue_family_indices,
                 &wire_vertices,
             );
+        let index_count = world_indices.len() as u32;
         let (index_buffer, index_buffer_memory) = buffers::create_index_buffer(
             &instance,
             &device,
             physical_device,
             &queue_family_indices,
-            &INDICES,
+            &world_indices,
         );
 
         let swapchain_loader = ash::extensions::khr::Swapchain::new(&instance, &device);
@@ -198,6 +200,7 @@ impl VulkanApp {
             wireframe_vertex_buffer,
             wireframe_vertex_buffer_memory,
             wireframe_vertex_count,
+            index_count,
             index_buffer,
             index_buffer_memory,
             uniform_buffers,

--- a/src/vulkan_app/buffers.rs
+++ b/src/vulkan_app/buffers.rs
@@ -3,7 +3,7 @@ use ash::vk;
 use cgmath::{Matrix4, SquareMatrix};
 
 
-use super::{utils::{QueueFamilyIndices, UniformBufferObject}, vertex::{Vertex, INDICES}, VulkanApp};
+use super::{utils::{QueueFamilyIndices, UniformBufferObject}, vertex::Vertex, VulkanApp};
 
 pub fn create_index_buffer(
     instance: &ash::Instance,
@@ -12,7 +12,7 @@ pub fn create_index_buffer(
     _indices: &QueueFamilyIndices,
     data: &[u16],
 ) -> (vk::Buffer, vk::DeviceMemory) {
-    let buffer_size = (std::mem::size_of::<u16>() * INDICES.len()) as vk::DeviceSize;
+    let buffer_size = (std::mem::size_of::<u16>() * data.len()) as vk::DeviceSize;
     let (buffer, buffer_memory) = create_buffer(
         instance,
         device,

--- a/src/vulkan_app/commands.rs
+++ b/src/vulkan_app/commands.rs
@@ -1,6 +1,6 @@
 use ash::{vk};
 
-use super::{utils::QueueFamilyIndices, vertex::{INDICES}, VulkanApp};
+use super::{utils::QueueFamilyIndices, VulkanApp};
 
 pub fn create_command_pool(device: &ash::Device, indices: &QueueFamilyIndices) -> vk::CommandPool {
     let pool_info = vk::CommandPoolCreateInfo::builder()
@@ -76,7 +76,7 @@ impl VulkanApp {
                 &[],
             );
             self.device
-                .cmd_draw_indexed(command_buffer, INDICES.len() as u32, 1, 0, 0, 0);
+                .cmd_draw_indexed(command_buffer, self.index_count, 1, 0, 0, 0);
             self.device.cmd_bind_pipeline(
                 command_buffer,
                 vk::PipelineBindPoint::GRAPHICS,

--- a/src/vulkan_app/vertex.rs
+++ b/src/vulkan_app/vertex.rs
@@ -144,3 +144,44 @@ pub fn generate_wireframe_vertices(divisions: u32) -> Vec<Vertex> {
 
     vertices
 }
+
+pub fn generate_flat_world(width: u32, depth: u32) -> (Vec<Vertex>, Vec<u16>, Vec<Vertex>) {
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+    let base_wire = generate_wireframe_vertices(24);
+    let mut wire_vertices = Vec::new();
+
+    for x in 0..width {
+        for y in 0..depth {
+            let offset = [
+                x as f32 - width as f32 / 2.0 + 0.0,
+                y as f32 - depth as f32 / 2.0 + 0.0,
+                0.5,
+            ];
+            let base_index = vertices.len() as u16;
+            for v in VERTICES.iter() {
+                vertices.push(Vertex {
+                    pos: [
+                        v.pos[0] + offset[0],
+                        v.pos[1] + offset[1],
+                        v.pos[2] + offset[2],
+                    ],
+                    color: v.color,
+                });
+            }
+            indices.extend(INDICES.iter().map(|&i| i + base_index));
+            for wv in base_wire.iter() {
+                wire_vertices.push(Vertex {
+                    pos: [
+                        wv.pos[0] + offset[0],
+                        wv.pos[1] + offset[1],
+                        wv.pos[2] + offset[2],
+                    ],
+                    color: wv.color,
+                });
+            }
+        }
+    }
+
+    (vertices, indices, wire_vertices)
+}


### PR DESCRIPTION
## Summary
- generate a grid of cubes using `generate_flat_world`
- store the total index count for drawing
- update command recording to use the new index count
- size vertex and index buffers from generated data

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6886986583348322afc3e77f59d2e794